### PR TITLE
OSC fix exception for avatar param not in json

### DIFF
--- a/OSC/Handlers/OscModules/Avatar.cs
+++ b/OSC/Handlers/OscModules/Avatar.cs
@@ -35,29 +35,25 @@ public class Avatar : OscHandler {
         _animatorManagerUpdated = InitializeNewAvatar;
 
         // Send avatar float parameter change events
-        _parameterChangedFloat = (parameter, value) =>
-        {
+        _parameterChangedFloat = (parameter, value) => {
             if (!_parameterAddressCache.ContainsKey(parameter)) return;
             SendAvatarParamToConfigAddress(parameter, ConvertToConfigType(parameter, value));
         };
 
         // Send avatar int parameter change events
-        _parameterChangedInt = (parameter, value) =>
-        {
+        _parameterChangedInt = (parameter, value) => {
             if (!_parameterAddressCache.ContainsKey(parameter)) return;
             SendAvatarParamToConfigAddress(parameter, ConvertToConfigType(parameter, value));
         };
 
         // Send avatar bool parameter change events
-        _parameterChangedBool = (parameter, value) =>
-        {
+        _parameterChangedBool = (parameter, value) => {
             if (!_parameterAddressCache.ContainsKey(parameter)) return;
             SendAvatarParamToConfigAddress(parameter, ConvertToConfigType(parameter, value));
         };
 
         // Send avatar trigger parameter change events
-        _parameterChangedTrigger = parameter =>
-        {
+        _parameterChangedTrigger = parameter => {
             if (!_parameterAddressCache.ContainsKey(parameter)) return;
             SendAvatarParamToConfigAddress(parameter, null);
         };

--- a/OSC/Handlers/OscModules/Avatar.cs
+++ b/OSC/Handlers/OscModules/Avatar.cs
@@ -35,16 +35,32 @@ public class Avatar : OscHandler {
         _animatorManagerUpdated = InitializeNewAvatar;
 
         // Send avatar float parameter change events
-        _parameterChangedFloat = (parameter, value) => SendAvatarParamToConfigAddress(parameter, ConvertToConfigType(parameter, value));
+        _parameterChangedFloat = (parameter, value) =>
+        {
+            if (!_parameterAddressCache.ContainsKey(parameter)) return;
+            SendAvatarParamToConfigAddress(parameter, ConvertToConfigType(parameter, value));
+        };
 
         // Send avatar int parameter change events
-        _parameterChangedInt = (parameter, value) => SendAvatarParamToConfigAddress(parameter, ConvertToConfigType(parameter, value));
+        _parameterChangedInt = (parameter, value) =>
+        {
+            if (!_parameterAddressCache.ContainsKey(parameter)) return;
+            SendAvatarParamToConfigAddress(parameter, ConvertToConfigType(parameter, value));
+        };
 
         // Send avatar bool parameter change events
-        _parameterChangedBool = (parameter, value) => SendAvatarParamToConfigAddress(parameter, ConvertToConfigType(parameter, value));
+        _parameterChangedBool = (parameter, value) =>
+        {
+            if (!_parameterAddressCache.ContainsKey(parameter)) return;
+            SendAvatarParamToConfigAddress(parameter, ConvertToConfigType(parameter, value));
+        };
 
         // Send avatar trigger parameter change events
-        _parameterChangedTrigger = parameter => SendAvatarParamToConfigAddress(parameter, null);
+        _parameterChangedTrigger = parameter =>
+        {
+            if (!_parameterAddressCache.ContainsKey(parameter)) return;
+            SendAvatarParamToConfigAddress(parameter, null);
+        };
 
         // Enable according to the config and setup the config listeners
         if (OSC.Instance.meOSCAvatarModule.Value) Enable();


### PR DESCRIPTION
We can intentionally filter out params we don't want to listen, like the CVR builtin movements etc. This fix allows to use this feature properly.