### PR TITLE
Small patch to add indicator bar to active icons

### DIFF
--- a/CCK.Debugger/Resources/UIResources/index.css
+++ b/CCK.Debugger/Resources/UIResources/index.css
@@ -121,7 +121,7 @@ html, body {
     background-position: center;
     text-align: center;
     margin: 10px 0 10px 0;
-    padding-right: 2.5em;
+    padding-right: 2.6em;
 }
 
 .cck-debugger-section-root {

--- a/CCK.Debugger/Resources/UIResources/index.css
+++ b/CCK.Debugger/Resources/UIResources/index.css
@@ -115,12 +115,13 @@ html, body {
 
 .cck-debugger-button {
     background-repeat: no-repeat;
-    background-size: contain;
+    background-size: 2.100000em 2.100000em;
     width: 100px;
     height: 100px;
     background-position: center;
     text-align: center;
     margin: 10px 0 10px 0;
+    padding-right: 2.5em;
 }
 
 .cck-debugger-section-root {
@@ -159,6 +160,11 @@ html, body {
 
 .cck-debugger-button.on {
     filter: drop-shadow(5px 5px 5px deeppink) drop-shadow(-5px -5px 5px deeppink);
+    border-left-width: medium;
+    border-left-color: rgba(0, 255, 255, 1.000000);
+    border-left-style: solid;
+    padding-left: 2.5em;
+    padding-right: 0.0em;
 }
 
 #cck-debugger-button-bone {

--- a/CCK.Debugger/Resources/UIResources/index.css
+++ b/CCK.Debugger/Resources/UIResources/index.css
@@ -115,7 +115,7 @@ html, body {
 
 .cck-debugger-button {
     background-repeat: no-repeat;
-    background-size: 2.100000em 2.100000em;
+    background-size: 2.1em 2.1em;
     width: 100px;
     height: 100px;
     background-position: center;

--- a/CCK.Debugger/Resources/UIResources/index.css
+++ b/CCK.Debugger/Resources/UIResources/index.css
@@ -161,7 +161,7 @@ html, body {
 .cck-debugger-button.on {
     filter: drop-shadow(5px 5px 5px deeppink) drop-shadow(-5px -5px 5px deeppink);
     border-left-width: medium;
-    border-left-color: rgba(0, 255, 255, 1.000000);
+    border-left-color: rgba(255, 255, 255, 1.000000);
     border-left-style: solid;
     padding-left: 2.5em;
     padding-right: 0.0em;


### PR DESCRIPTION
The intent of this merge is to make it easier to know if an icon is active or not.  
It can be hard for some to differential between active and inactive button colours.  
  
The following screenshot shows an example of the 'active' bar against the icons for features that are enabled  
![image](https://user-images.githubusercontent.com/31048789/227716187-fb267a9d-fb6f-4ad2-8d6f-51a8fa48aa48.png)
