### PR TITLE
Add folder create step for ManagedLibs dir

### DIFF
--- a/copy_and_nstrip_dll.ps1
+++ b/copy_and_nstrip_dll.ps1
@@ -31,6 +31,14 @@ else {
 $scriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
 $managedLibsFolder = $scriptDir + "\ManagedLibs"
 
+if (!(Test-Path $managedLibsFolder)) {
+    New-Item -ItemType Directory -Path $managedLibsFolder
+    Write-Output "ManagedLibs folder created successfully."
+}
+else {
+    Write-Output "ManagedLibs folder already exists."
+}
+
 Write-Host ""
 Write-Host "Copying the DLLs from the CVR, MelonLoader, and Mods folder to the ManagedLibs"
 

--- a/copy_and_nstrip_dll.ps1
+++ b/copy_and_nstrip_dll.ps1
@@ -33,7 +33,7 @@ $managedLibsFolder = $scriptDir + "\ManagedLibs"
 
 if (!(Test-Path $managedLibsFolder)) {
     New-Item -ItemType Directory -Path $managedLibsFolder
-    Write-Output "ManagedLibs folder created successfully."
+    Write-Host "ManagedLibs folder created successfully."
 }
 
 Write-Host ""

--- a/copy_and_nstrip_dll.ps1
+++ b/copy_and_nstrip_dll.ps1
@@ -35,9 +35,6 @@ if (!(Test-Path $managedLibsFolder)) {
     New-Item -ItemType Directory -Path $managedLibsFolder
     Write-Output "ManagedLibs folder created successfully."
 }
-else {
-    Write-Output "ManagedLibs folder already exists."
-}
 
 Write-Host ""
 Write-Host "Copying the DLLs from the CVR, MelonLoader, and Mods folder to the ManagedLibs"


### PR DESCRIPTION
This adds in a test/create dir step to the copy_and_nstrip_dll.ps1 file, to ensure that ManagedLibs folder exists/is created.

This is needed as without it, if the folder does not exist, you end up with an odd file in its place instead